### PR TITLE
Update to hotfix coda-26.04.2.4-2 tag

### DIFF
--- a/com.collaboraoffice.Office.json
+++ b/com.collaboraoffice.Office.json
@@ -127,8 +127,8 @@
         {
           "type": "git",
           "url": "https://gerrit.collaboraoffice.com/online",
-          "tag": "coda-26.04.2.4-1",
-          "commit": "5f9efbc209aba819ac7bea421de2f31e6c026521"
+          "tag": "coda-26.04.2.4-2",
+          "commit": "9e9db9c7fe45aa99b0a87101238a49ab99789e2d"
         },
         {
           "type": "git",


### PR DESCRIPTION
Added Caolan's https://gerrit.collaboraoffice.com/c/online/+/7687 to this release.